### PR TITLE
update package version to 0.1.7 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplify-js-local",
   "description": "Simple Amplify JS wrapper script for use with LocalStack",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "bin": {
     "amplifylocal": "bin/amplifylocal"
   },


### PR DESCRIPTION
Right now the NPM [package](https://www.npmjs.com/package/amplify-js-local/v/0.1.6?activeTab=readme) for this tool doesn't list the **esm** dependency. Updating the package version could fix that.  