### PR TITLE
Patch amplify endpoint env variable for newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ $ amplifylocal --version
 The following environment variables can be configured:
 
 * `EDGE_PORT`: Port under which LocalStack edge service is accessible (default: `4566`)
-* `LOCALSTACK_HOSTNAME`: Target host under which LocalStack edge service is accessible (default: `localhost`)
+* `LOCALSTACK_HOSTNAME`: Target host under which LocalStack edge service is accessible (default: `localhost.localstack.cloud`)
+* `LOCALSTACK_ENDPOINT`: Sets a custom endpoint directly. Overrides `EDGE_PORT` and `LOCALSTACK_HOSTNAME` (default `https://localhost.localstack.cloud:4566`)
 
 ## Deploying a Sample App via the CLI
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Amplify.configure(...);
 
 ## Change Log
 
+* 0.1.8: Patch AWS_AMPLIFY_ENDPOINT and add HTTPS support
+* 0.1.7: Include esm lib in the dependencies
 * 0.1.2: Patch AWS SDK clients (Cognito IdP/Identity) to use local endpoints
 * 0.1.1: Add patching for `@aws-amplify/auth` endpoints
 * 0.1.0: Initial release

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 
 // endpoint defaults
 const DEFAULT_EDGE_PORT = 4566;
-const DEFAULT_HOSTNAME = 'localhost';
+const DEFAULT_HOSTNAME = 'localhost.localstack.cloud';
 
 // TODO make configurable?
 const AWS_ACCESS_KEY_ID = 'test';
@@ -14,7 +14,7 @@ const AWS_SECRET_ACCESS_KEY = 'test';
 const getLocalEndpoint = () => {
   const port = process.env.EDGE_PORT || DEFAULT_EDGE_PORT;
   const host = process.env.LOCALSTACK_HOSTNAME || DEFAULT_HOSTNAME;
-  return `http://${host}:${port}`;
+  return `https://${host}:${port}`;
 };
 
 const patchAwsConfig = (config) => {
@@ -28,6 +28,10 @@ const setDefaultCredentials = () => {
   process.env.AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY_ID;
   process.env.AWS_SECRET_ACCESS_KEY = AWS_SECRET_ACCESS_KEY;
 };
+
+const patchEnvVariables = () =>{
+  process.env.AWS_AMPLIFY_ENDPOINT = getLocalEndpoint()
+}
 
 //---------
 // PATCHES
@@ -125,6 +129,9 @@ const patchAmplifyAuthEndpoint = (authInstance) => {
 const applyPatches = () => {
   // patch credentials
   setDefaultCredentials();
+
+  // patch env variables
+  patchEnvVariables();
 
   // patch configs
   patchAmplifyAuthEndpoint();

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const AWS_SECRET_ACCESS_KEY = 'test';
 const getLocalEndpoint = () => {
   const port = process.env.EDGE_PORT || DEFAULT_EDGE_PORT;
   const host = process.env.LOCALSTACK_HOSTNAME || DEFAULT_HOSTNAME;
-  return `https://${host}:${port}`;
+  return process.env.LOCALSTACK_ENDPOINT || `https://${host}:${port}`;
 };
 
 const patchAwsConfig = (config) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplify-js-local",
   "description": "Simple Amplify JS wrapper script for use with LocalStack",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "bin": {
     "amplifylocal": "bin/amplifylocal"
   },


### PR DESCRIPTION
This fixes #7. Patching directly the endpoint configuration on the library aws-amplify/cli library doesn't work in newer versions due to the package being an executable. To continue using the cli with Localstack there's the AWS_AMPLIFY_ENDPOINT environment variable.

Changes:
- Patching of AWS_AMPLIFY_ENDPOINT 
- Set default hostname to "localhost.localstack.cloud" 
- Use of HTTPS
- Config option to override generated LocalStack endpoint
